### PR TITLE
Custom loop points

### DIFF
--- a/Data/CustomMusicData.cs
+++ b/Data/CustomMusicData.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -8,7 +9,21 @@ namespace NickCustomMusicMod.Data
     {
         public float loopStartPointSec;
         public float loopEndPointSec;
-        public int loopStartPointSamples;
-        public int loopEndPointSamples;
+        public CustomLoopPoints loopPointsSamples;
+    }
+
+    class CustomLoopPoints
+    {
+        [JsonProperty("start")]
+        public int Start { get; private set; }
+
+        [JsonProperty("end")]
+        public int End { get; private set; }
+
+        public CustomLoopPoints(int startPoint, int endPoint) 
+        {
+            Start = startPoint;
+            End = endPoint;
+        }
     }
 }

--- a/Data/CustomMusicData.cs
+++ b/Data/CustomMusicData.cs
@@ -5,8 +5,10 @@ using System.Text;
 namespace NickCustomMusicMod.Data
 {
     class CustomMusicData
-	{
-		public float loopStartPointSec;
-		public float loopEndPointSec;
-	}
+    {
+        public float loopStartPointSec;
+        public float loopEndPointSec;
+        public int loopStartPointSamples;
+        public int loopEndPointSamples;
+    }
 }

--- a/Data/CustomMusicData.cs
+++ b/Data/CustomMusicData.cs
@@ -9,7 +9,7 @@ namespace NickCustomMusicMod.Data
     {
         public float loopStartPointSec;
         public float loopEndPointSec;
-        public CustomLoopPoints loopPointsSamples;
+        public CustomLoopPoints loopPoints;
     }
 
     class CustomLoopPoints

--- a/Data/CustomMusicData.cs
+++ b/Data/CustomMusicData.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace NickCustomMusicMod.Data
 {
@@ -20,10 +17,17 @@ namespace NickCustomMusicMod.Data
         [JsonProperty("end")]
         public int End { get; private set; }
 
-        public CustomLoopPoints(int startPoint, int endPoint) 
+        public CustomLoopPoints(int startPoint, int endPoint)
         {
             Start = startPoint;
             End = endPoint;
+        }
+
+        // Default constructor is used if class is not found in json file
+        public CustomLoopPoints()
+        {
+            Start = -1;
+            End = -1;
         }
     }
 }

--- a/Management/CustomMusicManager.cs
+++ b/Management/CustomMusicManager.cs
@@ -8,6 +8,7 @@ using BepInEx;
 using NickCustomMusicMod.Utils;
 using System.Threading;
 using UnityEngine.Localization;
+using NASB2CustomMusicMod.Management;
 
 namespace NickCustomMusicMod.Management
 {
@@ -17,7 +18,7 @@ namespace NickCustomMusicMod.Management
 
 		public static void Init()
         {
-			songDictionaries = new Dictionary<string, Dictionary<string, MusicTrack>>();
+			songDictionaries = new Dictionary<string, Dictionary<string, CustomMusicTrack>>();
 
 			rootCustomSongsPath = Path.Combine(Paths.BepInExRootPath, "CustomSongs");
 
@@ -86,7 +87,7 @@ namespace NickCustomMusicMod.Management
 			
 			string path = Path.Combine(rootCustomSongsPath, parentFolderName, folderName);
 
-			Dictionary<string, MusicTrack> MusicTrackDict = new Dictionary<string, MusicTrack>();
+			Dictionary<string, CustomMusicTrack> MusicTrackDict = new Dictionary<string, CustomMusicTrack>();
 
 			foreach (string songPath in from x in Directory.GetFiles(path)
 				where x.ToLower().EndsWith(".ogg") || x.ToLower().EndsWith(".wav") || x.ToLower().EndsWith(".mp3")
@@ -137,7 +138,7 @@ namespace NickCustomMusicMod.Management
 				string musicBankPath = Path.Combine(rootCustomSongsPath, Consts.songPacksFolderName, packName, Consts.musicBankFolderName);
 				string listPath = Path.Combine(folderPath, textFileName);
 
-				Dictionary<string, MusicTrack> MusicTrackDict = songDictionaries[constructDictionaryKey(folderName, Path.GetFileNameWithoutExtension(textFileName))];
+				Dictionary<string, CustomMusicTrack> MusicTrackDict = songDictionaries[constructDictionaryKey(folderName, Path.GetFileNameWithoutExtension(textFileName))];
 
 				foreach (string textLine in File.ReadLines(listPath))
 				{
@@ -148,12 +149,12 @@ namespace NickCustomMusicMod.Management
 			}
 		}
 
-		public static MusicTrack GetRandomCustomSong(string id)
+		public static CustomMusicTrack GetRandomCustomSong(string id)
 		{
             // Get a random song for this stage / menu
             if (songDictionaries.ContainsKey(id))
             {
-                Dictionary<string, MusicTrack> musicDict = songDictionaries[id];
+                Dictionary<string, CustomMusicTrack> musicDict = songDictionaries[id];
                 int numCustomSongs = musicDict.Keys.Count;
 
                 if (numCustomSongs > 0)
@@ -180,7 +181,7 @@ namespace NickCustomMusicMod.Management
                     else
                     {
                         string randomSong = musicDict.Keys.ToArray<string>()[randInt];
-                        MusicTrack musicEntry = musicDict[randomSong];
+                        CustomMusicTrack musicEntry = musicDict[randomSong];
 
                         // Intercept the ID and use our custom one
                         Plugin.LogDebug($"Intercepting GetMusic id: {id} and changing to {musicEntry.Id}");
@@ -215,7 +216,7 @@ namespace NickCustomMusicMod.Management
 				return $"{musicType}_{FileHandlingUtils.TranslateFolderNameToID(name)}";
 		}
 
-		private static bool addMusicTrackToDict(Dictionary<string, MusicTrack> MusicTrackDict, string songPath)
+		private static bool addMusicTrackToDict(Dictionary<string, CustomMusicTrack> MusicTrackDict, string songPath)
         {
 			if (File.Exists(songPath))
 			{
@@ -226,8 +227,8 @@ namespace NickCustomMusicMod.Management
                 // Fix this to actually have the correct text in it!
                 LocalizedString localizedString = new LocalizedString();
 
-				MusicTrack music = new MusicTrack
-				{
+                CustomMusicTrack music = new CustomMusicTrack
+                {
 					Id = "CUSTOM_" + fileNameWithoutExtension,
 					TrackName = localizedString,
 					Path = songPath,
@@ -253,7 +254,7 @@ namespace NickCustomMusicMod.Management
 			return false;
 		}
 
-		internal static Dictionary<string, Dictionary<string, MusicTrack>> songDictionaries;
+		internal static Dictionary<string, Dictionary<string, CustomMusicTrack>> songDictionaries;
 	}
 
 }

--- a/Management/CustomMusicTrack.cs
+++ b/Management/CustomMusicTrack.cs
@@ -9,6 +9,6 @@ namespace NASB2CustomMusicMod.Management
     {
         public float LoopStartPointSec;
         public float LoopEndPointSec;
-        public CustomLoopPoints LoopPointsSamples;
+        public CustomLoopPoints LoopPoints;
     }
 }

--- a/Management/CustomMusicTrack.cs
+++ b/Management/CustomMusicTrack.cs
@@ -9,7 +9,6 @@ namespace NASB2CustomMusicMod.Management
     {
         public float LoopStartPointSec;
         public float LoopEndPointSec;
-        public int LoopStartPointSamples;
-        public int LoopEndPointSamples;
+        public CustomLoopPoints LoopPointsSamples;
     }
 }

--- a/Management/CustomMusicTrack.cs
+++ b/Management/CustomMusicTrack.cs
@@ -1,0 +1,15 @@
+﻿using NickCustomMusicMod.Data;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NASB2CustomMusicMod.Management
+{
+    internal class CustomMusicTrack : MusicTrack
+    {
+        public float LoopStartPointSec;
+        public float LoopEndPointSec;
+        public int LoopStartPointSamples;
+        public int LoopEndPointSamples;
+    }
+}

--- a/NASB2CustomMusicMod.csproj
+++ b/NASB2CustomMusicMod.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>0.3.1</Version>
-    <AssemblyVersion>0.3.1</AssemblyVersion>
-    <FileVersion>0.3.1</FileVersion>
+    <Version>0.4.0</Version>
+    <AssemblyVersion>0.4.0</AssemblyVersion>
+    <FileVersion>0.4.0</FileVersion>
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/Patches/MusicManager_StartPlayingMusic.cs
+++ b/Patches/MusicManager_StartPlayingMusic.cs
@@ -10,6 +10,7 @@ using NickCustomMusicMod;
 using NASB2CustomMusicMod.Utils;
 using NickCustomMusicMod.Management;
 using UnityEngine.UI;
+using NASB2CustomMusicMod.Management;
 
 namespace NASB2CustomMusicMod.Patches
 {
@@ -47,15 +48,16 @@ namespace NASB2CustomMusicMod.Patches
 
                 //if (CheckToSkipOnlineMenuMusic(ref id)) return false;
 
-                MusicTrack customTrack = CustomMusicManager.GetRandomCustomSong(id);
+                Plugin.customTrack = null;
+                Plugin.customTrack = CustomMusicManager.GetRandomCustomSong(id);
 
-                if (customTrack == null)
+                if (Plugin.customTrack == null)
                 {
                     Plugin.playingCustomSong = false;
                 } else
                 {
                     Plugin.playingCustomSong = true;
-                    __instance.StartCoroutine(SongLoader.LoadCustomSong(customTrack, musicSource));
+                    __instance.StartCoroutine(SongLoader.LoadCustomSong(Plugin.customTrack, musicSource));
                 }
 
                 // ----

--- a/Patches/MusicManager_Update.cs
+++ b/Patches/MusicManager_Update.cs
@@ -60,12 +60,12 @@ namespace NASB2CustomMusicMod.Patches
             }
 
             // Loop
-            if (Plugin.customTrack.LoopPointsSamples != null && Plugin.customTrack.LoopPointsSamples.Start >= 0 && Plugin.customTrack.LoopPointsSamples.End > 0)
+            if (Plugin.customTrack.LoopPoints != null && Plugin.customTrack.LoopPoints.Start >= 0 && Plugin.customTrack.LoopPoints.End > 0)
             {
-                if (firstMusicSource.timeSamples >= Plugin.customTrack.LoopPointsSamples.End)
+                if (firstMusicSource.timeSamples >= Plugin.customTrack.LoopPoints.End)
                 {
-                    Plugin.LogWarning($"Looping! firstMusicSource.timeSamples: {firstMusicSource.timeSamples} | Loop points: {Plugin.customTrack.LoopPointsSamples.Start}, {Plugin.customTrack.LoopPointsSamples.End}");
-                    firstMusicSource.timeSamples -= (Plugin.customTrack.LoopPointsSamples.End - Plugin.customTrack.LoopPointsSamples.Start);
+                    Plugin.LogWarning($"Looping! firstMusicSource.timeSamples: {firstMusicSource.timeSamples} | Loop points: {Plugin.customTrack.LoopPoints.Start}, {Plugin.customTrack.LoopPoints.End}");
+                    firstMusicSource.timeSamples -= (Plugin.customTrack.LoopPoints.End - Plugin.customTrack.LoopPoints.Start);
                 }
             } else if (Plugin.customTrack.LoopStartPointSec >= 0 && Plugin.customTrack.LoopEndPointSec > 0)
             {

--- a/Patches/MusicManager_Update.cs
+++ b/Patches/MusicManager_Update.cs
@@ -58,8 +58,11 @@ namespace NASB2CustomMusicMod.Patches
                     }
                 }
             }
-
+                
             // Loop
+
+            if (Plugin.customTrack == null) return false;
+
             if (Plugin.customTrack.LoopPoints != null && Plugin.customTrack.LoopPoints.Start >= 0 && Plugin.customTrack.LoopPoints.End > 0)
             {
                 if (firstMusicSource.timeSamples >= Plugin.customTrack.LoopPoints.End)
@@ -67,7 +70,8 @@ namespace NASB2CustomMusicMod.Patches
                     Plugin.LogWarning($"Looping! firstMusicSource.timeSamples: {firstMusicSource.timeSamples} | Loop points: {Plugin.customTrack.LoopPoints.Start}, {Plugin.customTrack.LoopPoints.End}");
                     firstMusicSource.timeSamples -= (Plugin.customTrack.LoopPoints.End - Plugin.customTrack.LoopPoints.Start);
                 }
-            } else if (Plugin.customTrack.LoopStartPointSec >= 0 && Plugin.customTrack.LoopEndPointSec > 0)
+            }
+            else if (Plugin.customTrack.LoopStartPointSec >= 0 && Plugin.customTrack.LoopEndPointSec > 0)
             {
                 if (firstMusicSource.time >= Plugin.customTrack.LoopEndPointSec)
                 {

--- a/Patches/MusicManager_Update.cs
+++ b/Patches/MusicManager_Update.cs
@@ -60,12 +60,12 @@ namespace NASB2CustomMusicMod.Patches
             }
 
             // Loop
-            if (Plugin.customTrack.LoopStartPointSamples >= 0 && Plugin.customTrack.LoopEndPointSamples > 0)
+            if (Plugin.customTrack.LoopPointsSamples != null && Plugin.customTrack.LoopPointsSamples.Start >= 0 && Plugin.customTrack.LoopPointsSamples.End > 0)
             {
-                if (firstMusicSource.timeSamples >= Plugin.customTrack.LoopEndPointSamples)
+                if (firstMusicSource.timeSamples >= Plugin.customTrack.LoopPointsSamples.End)
                 {
-                    Plugin.LogWarning($"Looping! firstMusicSource.timeSamples: {firstMusicSource.timeSamples} | Loop points: {Plugin.customTrack.LoopStartPointSamples}, {Plugin.customTrack.LoopEndPointSamples}");
-                    firstMusicSource.timeSamples -= (Plugin.customTrack.LoopEndPointSamples - Plugin.customTrack.LoopStartPointSamples);
+                    Plugin.LogWarning($"Looping! firstMusicSource.timeSamples: {firstMusicSource.timeSamples} | Loop points: {Plugin.customTrack.LoopPointsSamples.Start}, {Plugin.customTrack.LoopPointsSamples.End}");
+                    firstMusicSource.timeSamples -= (Plugin.customTrack.LoopPointsSamples.End - Plugin.customTrack.LoopPointsSamples.Start);
                 }
             } else if (Plugin.customTrack.LoopStartPointSec >= 0 && Plugin.customTrack.LoopEndPointSec > 0)
             {

--- a/Patches/MusicManager_Update.cs
+++ b/Patches/MusicManager_Update.cs
@@ -7,12 +7,15 @@ using UnityEngine;
 using UnityEngine.Localization.SmartFormat.Core.Parsing;
 using SMU.Reflection;
 using NickCustomMusicMod;
+using UnityEngine.Localization.SmartFormat.Core.Extensions;
 
 namespace NASB2CustomMusicMod.Patches
 {
     [HarmonyPatch(typeof(MusicManager), "Update")]
     internal class MusicManager_Update
     {
+        private static AudioSource firstMusicSource;
+
         /*
          * This builtin function is a mess.
          * I'm replacing it with a rewritten version that is functionally the same
@@ -24,7 +27,9 @@ namespace NASB2CustomMusicMod.Patches
                 return false;
             }
 
-            if (!Plugin.playingCustomSong && __instance.MusicSources[0].time >= __instance.EndTime)
+            firstMusicSource = __instance.MusicSources[0];
+
+            if (!Plugin.playingCustomSong && firstMusicSource.time >= __instance.EndTime)
             {
                 foreach (AudioSource musicSource in __instance.MusicSources)
                 {
@@ -37,7 +42,7 @@ namespace NASB2CustomMusicMod.Patches
 
             if (__instance.GetField<MusicManager, bool>("paused")) return false;
 
-            if (!__instance.MusicSources[0].isPlaying)
+            if (!firstMusicSource.isPlaying)
             {
                 foreach (AudioSource musicSource in __instance.MusicSources)
                 {
@@ -51,6 +56,23 @@ namespace NASB2CustomMusicMod.Patches
                         Plugin.LogInfo("MusicManager_Update: Playing song!");
                         musicSource.Play();
                     }
+                }
+            }
+
+            // Loop
+            if (Plugin.customTrack.LoopStartPointSamples >= 0 && Plugin.customTrack.LoopEndPointSamples > 0)
+            {
+                if (firstMusicSource.timeSamples >= Plugin.customTrack.LoopEndPointSamples)
+                {
+                    Plugin.LogWarning($"Looping! firstMusicSource.timeSamples: {firstMusicSource.timeSamples} | Loop points: {Plugin.customTrack.LoopStartPointSamples}, {Plugin.customTrack.LoopEndPointSamples}");
+                    firstMusicSource.timeSamples -= (Plugin.customTrack.LoopEndPointSamples - Plugin.customTrack.LoopStartPointSamples);
+                }
+            } else if (Plugin.customTrack.LoopStartPointSec >= 0 && Plugin.customTrack.LoopEndPointSec > 0)
+            {
+                if (firstMusicSource.time >= Plugin.customTrack.LoopEndPointSec)
+                {
+                    Plugin.LogWarning($"Looping! firstMusicSource.time: {firstMusicSource.time} | Loop points: {Plugin.customTrack.LoopStartPointSec}, {Plugin.customTrack.LoopEndPointSec}");
+                    firstMusicSource.time -= (Plugin.customTrack.LoopEndPointSec - Plugin.customTrack.LoopStartPointSec);
                 }
             }
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -5,6 +5,7 @@ using System;
 using System.Reflection;
 using NickCustomMusicMod.Management;
 using BepInEx.Configuration;
+using NASB2CustomMusicMod.Management;
 
 namespace NickCustomMusicMod
 {
@@ -14,6 +15,7 @@ namespace NickCustomMusicMod
         internal static Plugin Instance;
         internal static string previousMusicID;
         internal static bool playingCustomSong;
+        internal static CustomMusicTrack customTrack;
         internal ConfigEntry<bool> useDefaultSongs;
         internal ConfigEntry<bool> skipOnlineMenuMusicIfEmpty;
         private void Awake()

--- a/PluginInfo.cs
+++ b/PluginInfo.cs
@@ -8,6 +8,6 @@ namespace NickCustomMusicMod
     {
         public const string PLUGIN_GUID = "megalon.nasb2_custom_music_mod";
         public const string PLUGIN_NAME = "NASB2CustomMusicMod";
-        public const string PLUGIN_VERSION = "0.3.1";
+        public const string PLUGIN_VERSION = "0.4.0";
     }
 }

--- a/Utils/SongLoader.cs
+++ b/Utils/SongLoader.cs
@@ -76,7 +76,7 @@ namespace NASB2CustomMusicMod.Utils
 
             entry.LoopStartPointSec = -1;
             entry.LoopEndPointSec = -1;
-            entry.LoopPointsSamples = null;
+            entry.LoopPoints = null;
 
             // Get loop points from json file here
             string jsonPath = Path.Combine(Path.GetDirectoryName(entry.Path), Path.GetFileNameWithoutExtension(entry.Path) + ".json");
@@ -86,21 +86,23 @@ namespace NASB2CustomMusicMod.Utils
                 {
                     string jsonFile = File.ReadAllText(jsonPath);
 
+                    Plugin.LogDebug(jsonFile);
+
                     var customMusicData = JsonConvert.DeserializeObject<CustomMusicData>(jsonFile, null);
 
                     customMusicData.loopStartPointSec = Mathf.Clamp(customMusicData.loopStartPointSec, 0, musicSource.clip.length);
                     customMusicData.loopEndPointSec = Mathf.Clamp(customMusicData.loopEndPointSec, 0, musicSource.clip.length);
-                    customMusicData.loopPointsSamples = new CustomLoopPoints(
-                        Mathf.Clamp(customMusicData.loopPointsSamples.Start, 0, musicSource.clip.samples),
-                        Mathf.Clamp(customMusicData.loopPointsSamples.End, 0, musicSource.clip.samples)
+                    customMusicData.loopPoints = new CustomLoopPoints(
+                        Mathf.Clamp(customMusicData.loopPoints.Start, 0, musicSource.clip.samples),
+                        Mathf.Clamp(customMusicData.loopPoints.End, 0, musicSource.clip.samples)
                     );
 
                     Plugin.LogInfo($"customMusicData: {customMusicData.loopStartPointSec}, {customMusicData.loopEndPointSec}");
 
                     LogMessage_DataIsZero(customMusicData.loopStartPointSec, "customMusicData.loopStartPointSec", jsonPath);
                     LogMessage_DataIsZero(customMusicData.loopEndPointSec, "customMusicData.loopEndPointSec", jsonPath);
-                    LogMessage_DataIsZero(customMusicData.loopPointsSamples.Start, "customMusicData.loopPointsSamples.StartPoint", jsonPath);
-                    LogMessage_DataIsZero(customMusicData.loopPointsSamples.End, "customMusicData.loopPointsSamples.EndPoint", jsonPath);
+                    LogMessage_DataIsZero(customMusicData.loopPoints.Start, "customMusicData.loopPointsSamples.StartPoint", jsonPath);
+                    LogMessage_DataIsZero(customMusicData.loopPoints.End, "customMusicData.loopPointsSamples.EndPoint", jsonPath);
 
                     if (customMusicData.loopEndPointSec == 0 && customMusicData.loopStartPointSec > 0)
                     {
@@ -108,10 +110,10 @@ namespace NASB2CustomMusicMod.Utils
                         customMusicData.loopEndPointSec = musicSource.clip.length;
                     }
 
-                    if (customMusicData.loopPointsSamples.End == 0 && customMusicData.loopPointsSamples.Start > 0)
+                    if (customMusicData.loopPoints.End == 0 && customMusicData.loopPoints.Start > 0)
                     {
                         Plugin.LogWarning($"\"loopPointsSamples\" start is greater than 0, but \"loopPointsSamples\" end is 0! Setting end to length of song for \"{jsonPath}\"");
-                        customMusicData.loopPointsSamples = new CustomLoopPoints(customMusicData.loopPointsSamples.Start, musicSource.clip.samples);
+                        customMusicData.loopPoints = new CustomLoopPoints(customMusicData.loopPoints.Start, musicSource.clip.samples);
                     }
 
                     if (customMusicData.loopEndPointSec > 0 && customMusicData.loopStartPointSec > 0 && customMusicData.loopStartPointSec == customMusicData.loopEndPointSec)
@@ -119,14 +121,14 @@ namespace NASB2CustomMusicMod.Utils
                         Plugin.LogWarning($"\"loopStartPointSec\" and \"loopEndPointSec\" are the same value for \"{jsonPath}\"! Did you mean to do that?");
                     }
 
-                    if (customMusicData.loopPointsSamples.End > 0 && customMusicData.loopPointsSamples.Start > 0 && customMusicData.loopPointsSamples.Start == customMusicData.loopPointsSamples.End)
+                    if (customMusicData.loopPoints.End > 0 && customMusicData.loopPoints.Start > 0 && customMusicData.loopPoints.Start == customMusicData.loopPoints.End)
                     {
                         Plugin.LogWarning($"\"loopPointsSamples\" start and end points are the same value for \"{jsonPath}\"! Did you mean to do that?");
                     }
 
                     entry.LoopStartPointSec = customMusicData.loopStartPointSec;
                     entry.LoopEndPointSec = customMusicData.loopEndPointSec;
-                    entry.LoopPointsSamples = customMusicData.loopPointsSamples;
+                    entry.LoopPoints = customMusicData.loopPoints;
                 }
                 catch (Exception e)
                 {

--- a/Utils/SongLoader.cs
+++ b/Utils/SongLoader.cs
@@ -76,8 +76,7 @@ namespace NASB2CustomMusicMod.Utils
 
             entry.LoopStartPointSec = -1;
             entry.LoopEndPointSec = -1;
-            entry.LoopStartPointSamples = -1;
-            entry.LoopEndPointSamples = -1;
+            entry.LoopPointsSamples = null;
 
             // Get loop points from json file here
             string jsonPath = Path.Combine(Path.GetDirectoryName(entry.Path), Path.GetFileNameWithoutExtension(entry.Path) + ".json");
@@ -91,15 +90,17 @@ namespace NASB2CustomMusicMod.Utils
 
                     customMusicData.loopStartPointSec = Mathf.Clamp(customMusicData.loopStartPointSec, 0, musicSource.clip.length);
                     customMusicData.loopEndPointSec = Mathf.Clamp(customMusicData.loopEndPointSec, 0, musicSource.clip.length);
-                    customMusicData.loopStartPointSamples = Mathf.Clamp(customMusicData.loopStartPointSamples, 0, musicSource.clip.samples);
-                    customMusicData.loopEndPointSamples = Mathf.Clamp(customMusicData.loopEndPointSamples, 0, musicSource.clip.samples);
+                    customMusicData.loopPointsSamples = new CustomLoopPoints(
+                        Mathf.Clamp(customMusicData.loopPointsSamples.Start, 0, musicSource.clip.samples),
+                        Mathf.Clamp(customMusicData.loopPointsSamples.End, 0, musicSource.clip.samples)
+                    );
 
                     Plugin.LogInfo($"customMusicData: {customMusicData.loopStartPointSec}, {customMusicData.loopEndPointSec}");
 
                     LogMessage_DataIsZero(customMusicData.loopStartPointSec, "customMusicData.loopStartPointSec", jsonPath);
                     LogMessage_DataIsZero(customMusicData.loopEndPointSec, "customMusicData.loopEndPointSec", jsonPath);
-                    LogMessage_DataIsZero(customMusicData.loopStartPointSamples, "customMusicData.loopStartPointSamples", jsonPath);
-                    LogMessage_DataIsZero(customMusicData.loopEndPointSamples, "customMusicData.loopEndPointSamples", jsonPath);
+                    LogMessage_DataIsZero(customMusicData.loopPointsSamples.Start, "customMusicData.loopPointsSamples.StartPoint", jsonPath);
+                    LogMessage_DataIsZero(customMusicData.loopPointsSamples.End, "customMusicData.loopPointsSamples.EndPoint", jsonPath);
 
                     if (customMusicData.loopEndPointSec == 0 && customMusicData.loopStartPointSec > 0)
                     {
@@ -107,10 +108,10 @@ namespace NASB2CustomMusicMod.Utils
                         customMusicData.loopEndPointSec = musicSource.clip.length;
                     }
 
-                    if (customMusicData.loopEndPointSamples == 0 && customMusicData.loopStartPointSamples > 0)
+                    if (customMusicData.loopPointsSamples.End == 0 && customMusicData.loopPointsSamples.Start > 0)
                     {
-                        Plugin.LogWarning($"\"loopStartPointSamples\" is greater than 0, but \"loopEndPointSamples\" is 0! Setting \"loopEndPointSamples\" to length of song for \"{jsonPath}\"");
-                        customMusicData.loopEndPointSamples = musicSource.clip.samples;
+                        Plugin.LogWarning($"\"loopPointsSamples\" start is greater than 0, but \"loopPointsSamples\" end is 0! Setting end to length of song for \"{jsonPath}\"");
+                        customMusicData.loopPointsSamples = new CustomLoopPoints(customMusicData.loopPointsSamples.Start, musicSource.clip.samples);
                     }
 
                     if (customMusicData.loopEndPointSec > 0 && customMusicData.loopStartPointSec > 0 && customMusicData.loopStartPointSec == customMusicData.loopEndPointSec)
@@ -118,15 +119,14 @@ namespace NASB2CustomMusicMod.Utils
                         Plugin.LogWarning($"\"loopStartPointSec\" and \"loopEndPointSec\" are the same value for \"{jsonPath}\"! Did you mean to do that?");
                     }
 
-                    if (customMusicData.loopEndPointSamples > 0 && customMusicData.loopStartPointSamples > 0 && customMusicData.loopStartPointSamples == customMusicData.loopEndPointSamples)
+                    if (customMusicData.loopPointsSamples.End > 0 && customMusicData.loopPointsSamples.Start > 0 && customMusicData.loopPointsSamples.Start == customMusicData.loopPointsSamples.End)
                     {
-                        Plugin.LogWarning($"\"loopStartPointSamples\" and \"loopEndPointSamples\" are the same value for \"{jsonPath}\"! Did you mean to do that?");
+                        Plugin.LogWarning($"\"loopPointsSamples\" start and end points are the same value for \"{jsonPath}\"! Did you mean to do that?");
                     }
 
                     entry.LoopStartPointSec = customMusicData.loopStartPointSec;
                     entry.LoopEndPointSec = customMusicData.loopEndPointSec;
-                    entry.LoopStartPointSamples = customMusicData.loopStartPointSamples;
-                    entry.LoopEndPointSamples = customMusicData.loopEndPointSamples;
+                    entry.LoopPointsSamples = customMusicData.loopPointsSamples;
                 }
                 catch (Exception e)
                 {

--- a/Utils/SongLoader.cs
+++ b/Utils/SongLoader.cs
@@ -92,6 +92,7 @@ namespace NASB2CustomMusicMod.Utils
 
                     customMusicData.loopStartPointSec = Mathf.Clamp(customMusicData.loopStartPointSec, 0, musicSource.clip.length);
                     customMusicData.loopEndPointSec = Mathf.Clamp(customMusicData.loopEndPointSec, 0, musicSource.clip.length);
+
                     customMusicData.loopPoints = new CustomLoopPoints(
                         Mathf.Clamp(customMusicData.loopPoints.Start, 0, musicSource.clip.samples),
                         Mathf.Clamp(customMusicData.loopPoints.End, 0, musicSource.clip.samples)

--- a/Utils/SongLoader.cs
+++ b/Utils/SongLoader.cs
@@ -6,12 +6,16 @@ using System.IO;
 using System.Text;
 using UnityEngine.Networking;
 using UnityEngine;
+using Newtonsoft.Json;
+using NickCustomMusicMod.Data;
+using NASB2CustomMusicMod.Management;
+using System.Reflection;
 
 namespace NASB2CustomMusicMod.Utils
 {
     internal class SongLoader
     {
-        public static IEnumerator LoadCustomSong(MusicTrack track, AudioSource musicSource)
+        public static IEnumerator LoadCustomSong(CustomMusicTrack track, AudioSource musicSource)
         {
             //Plugin.LogInfo("Loading song: " + track.Path);
 
@@ -59,14 +63,93 @@ namespace NASB2CustomMusicMod.Utils
 
             //musicSource.volume = 1;
 
-            // !!!!!! TODO !!!!!!
-            // !!!!!! TODO !!!!!!
-            // !!!!!! TODO !!!!!!
-            // !!!!!! TODO !!!!!!
             // Handle custom music data here
-            // HandleCustomMusicData(entry, music);
+            Plugin.LogInfo("Calling HandleCustomMusicData...");
+            HandleCustomMusicData(track, musicSource);
 
             yield break;
+        }
+
+        private static void HandleCustomMusicData(CustomMusicTrack entry, AudioSource musicSource)
+        {
+            Plugin.LogInfo("Loading custom music data for:" + entry.Path);
+
+            entry.LoopStartPointSec = -1;
+            entry.LoopEndPointSec = -1;
+            entry.LoopStartPointSamples = -1;
+            entry.LoopEndPointSamples = -1;
+
+            // Get loop points from json file here
+            string jsonPath = Path.Combine(Path.GetDirectoryName(entry.Path), Path.GetFileNameWithoutExtension(entry.Path) + ".json");
+            if (File.Exists(jsonPath))
+            {
+                try
+                {
+                    string jsonFile = File.ReadAllText(jsonPath);
+
+                    var customMusicData = JsonConvert.DeserializeObject<CustomMusicData>(jsonFile, null);
+
+                    customMusicData.loopStartPointSec = Mathf.Clamp(customMusicData.loopStartPointSec, 0, musicSource.clip.length);
+                    customMusicData.loopEndPointSec = Mathf.Clamp(customMusicData.loopEndPointSec, 0, musicSource.clip.length);
+                    customMusicData.loopStartPointSamples = Mathf.Clamp(customMusicData.loopStartPointSamples, 0, musicSource.clip.samples);
+                    customMusicData.loopEndPointSamples = Mathf.Clamp(customMusicData.loopEndPointSamples, 0, musicSource.clip.samples);
+
+                    Plugin.LogInfo($"customMusicData: {customMusicData.loopStartPointSec}, {customMusicData.loopEndPointSec}");
+
+                    LogMessage_DataIsZero(customMusicData.loopStartPointSec, "customMusicData.loopStartPointSec", jsonPath);
+                    LogMessage_DataIsZero(customMusicData.loopEndPointSec, "customMusicData.loopEndPointSec", jsonPath);
+                    LogMessage_DataIsZero(customMusicData.loopStartPointSamples, "customMusicData.loopStartPointSamples", jsonPath);
+                    LogMessage_DataIsZero(customMusicData.loopEndPointSamples, "customMusicData.loopEndPointSamples", jsonPath);
+
+                    if (customMusicData.loopEndPointSec == 0 && customMusicData.loopStartPointSec > 0)
+                    {
+                        Plugin.LogWarning($"\"loopStartPointSec\" is greater than 0, but \"loopEndPointSec\" is 0! Setting \"loopEndPointSec\" to length of song for \"{jsonPath}\"");
+                        customMusicData.loopEndPointSec = musicSource.clip.length;
+                    }
+
+                    if (customMusicData.loopEndPointSamples == 0 && customMusicData.loopStartPointSamples > 0)
+                    {
+                        Plugin.LogWarning($"\"loopStartPointSamples\" is greater than 0, but \"loopEndPointSamples\" is 0! Setting \"loopEndPointSamples\" to length of song for \"{jsonPath}\"");
+                        customMusicData.loopEndPointSamples = musicSource.clip.samples;
+                    }
+
+                    if (customMusicData.loopEndPointSec > 0 && customMusicData.loopStartPointSec > 0 && customMusicData.loopStartPointSec == customMusicData.loopEndPointSec)
+                    {
+                        Plugin.LogWarning($"\"loopStartPointSec\" and \"loopEndPointSec\" are the same value for \"{jsonPath}\"! Did you mean to do that?");
+                    }
+
+                    if (customMusicData.loopEndPointSamples > 0 && customMusicData.loopStartPointSamples > 0 && customMusicData.loopStartPointSamples == customMusicData.loopEndPointSamples)
+                    {
+                        Plugin.LogWarning($"\"loopStartPointSamples\" and \"loopEndPointSamples\" are the same value for \"{jsonPath}\"! Did you mean to do that?");
+                    }
+
+                    entry.LoopStartPointSec = customMusicData.loopStartPointSec;
+                    entry.LoopEndPointSec = customMusicData.loopEndPointSec;
+                    entry.LoopStartPointSamples = customMusicData.loopStartPointSamples;
+                    entry.LoopEndPointSamples = customMusicData.loopEndPointSamples;
+                }
+                catch (Exception e)
+                {
+                    Plugin.LogError($"Error reading json data for {jsonPath}");
+                    Plugin.LogError(e.Message);
+                }
+            }
+            else
+            {
+                Plugin.LogInfo($"No json file found for {Path.GetFileName(entry.Path)}");
+            }
+        }
+
+        private static void LogMessage_DataIsZero(int val, string fieldName, string jsonPath)
+        {
+            LogMessage_DataIsZero((float)val, fieldName, jsonPath);
+        }
+
+        private static void LogMessage_DataIsZero(float val, string fieldName, string jsonPath)
+        {
+            if (val != 0) return;
+
+            Plugin.LogDebug($"\"{fieldName}\" is 0 for json file \"{jsonPath}\"! It might not be in the file, or is misspelled!");
         }
     }
 }


### PR DESCRIPTION
Adds the following custom data

- loopPoints
- loopStartPointSec
- loopEndPointSec

This data is loaded from a `.json` file of the same name as the audio file, similar to the mod in NASB1.

`loopPoints` uses *Samples* whereas `loopStartPointSec` and `loopStartPointSec` use *Seconds*. You do not need both. If both are present in the json file, then `loopPoints` takes priority because samples are more precise.

Example
```json
{
  "loopPoints": { "start": 199665, "end": 398612 }
  "loopStartPointSec": "3.109",
  "loopEndPointSec": "4.215",
}
```

Closes #6 